### PR TITLE
Replace cbor with serde_cbor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.42"
 bitcoin_hashes = "0.10.0"
-cbor = "0.4.1"
 crc = "2.0.0"
 hex = "0.4.3"
 phf = { version = "0.9.0", features = ["macros"] }
 rand_xoshiro = "0.6.0"
+serde = "1.0.126"
+serde_cbor = "0.11.1"
+serde_derive = "1.0.126"
 
 [dev-dependencies]
 

--- a/src/ur.rs
+++ b/src/ur.rs
@@ -58,7 +58,7 @@ impl Decoder {
     pub fn receive(&mut self, value: &str) -> anyhow::Result<()> {
         let decoded = Self::decode(value)?;
         self.fountain
-            .receive(crate::fountain::Part::from_cbor(decoded)?)?;
+            .receive(crate::fountain::Part::from_cbor(decoded.as_slice())?)?;
         Ok(())
     }
 
@@ -75,14 +75,11 @@ impl Decoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_cbor::Value;
 
     fn make_message_ur(length: usize, seed: &str) -> Vec<u8> {
         let message = crate::xoshiro::test_utils::make_message(seed, length);
-        let mut encoder = cbor::Encoder::from_memory();
-        encoder
-            .encode(vec![cbor::Cbor::Bytes(cbor::CborBytes(message))])
-            .unwrap();
-        encoder.as_bytes().to_vec()
+        serde_cbor::to_vec(&Value::Bytes(message)).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Removed `invalid cbor length for Part` error as it seems not possible to produce from `serde_cbor`.