### PR TITLE
Encoder: add support for UR types other than 'bytes'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ hex = "0.4.3"
 phf = { version = "0.10.0", features = ["macros"] }
 rand_xoshiro = "0.6.0"
 serde = "1.0.130"
-serde_cbor = "0.11.2"
+serde_cbor = { version = "0.11.2", features = ["tags"] }
 serde_derive = "1.0.130"
 thiserror = "1.0.30"
 
 [dev-dependencies]
-


### PR DESCRIPTION
An attempt to fix https://github.com/dspicher/ur-rs/issues/8. Test is implementing `crypto-request` UR type from [here](https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/ur-99-request-response.md).