### PR TITLE
ci: skip lock-file check in fuzz crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,5 +39,5 @@ jobs:
       run: |
         cargo fmt -- --check
         cargo sort-ck
-        cargo check --locked
+        cargo check
         cargo clippy --all --all-targets --all-features -- -Dwarnings -D clippy::pedantic -D clippy::dbg-macro -D clippy::indexing-slicing -A clippy::missing-panics-doc


### PR DESCRIPTION
As dependabot doesn't update the fuzz `Cargo.lock`, this otherwise
breaks the CI for its PRs.