### PR TITLE
ci: pin fuzz toolchain to 1.58

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.58
           override: true
           profile: minimal
       - run: cargo install honggfuzz


### PR DESCRIPTION
Looks like 1.59 broke the code generated
by honggfuzz-rs.