### PR TITLE
ur: indicate whether ur is multi-part when decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added `ur::ur::decode` to the public API to decode a single `ur` URI.
  - Added `ur::ur::encode` and `ur::ur::decode` to the root library path.
  - Bumped the Rust edition to 2021. #113
+ - Added an enum indicating whether the UR was single- or multip-part to `ur::ur::decode` https://github.com/dspicher/ur-rs/pull/121
 
 ## [0.2.0] - 2021-12-08
  - The public API has been greatly restricted


### PR DESCRIPTION
Add an enum to the return type. This can be used by
callers that don't know a-priori whether the UR is
single- or multi-part.