### PR TITLE
ci: replace cargo-sort-ck with cargo-sort

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,10 +20,10 @@ jobs:
       run: cargo --version
     - name: Format
       run: cargo fmt -- --check
-    - name: Install cargo-sort-ck
-      run: cargo install cargo-sort-ck
+    - name: Install cargo-sort
+      run: cargo install cargo-sort
     - name: Check sorted dependencies
-      run: cargo sort-ck
+      run: cargo sort --check
     - name: Check README is up-to-date
       run: cargo install cargo-rdme && cargo rdme --check
     - name: Check
@@ -38,6 +38,6 @@ jobs:
       working-directory: ./fuzz
       run: |
         cargo fmt -- --check
-        cargo sort-ck
+        cargo sort --check
         cargo check
         cargo clippy --all --all-targets --all-features -- -Dwarnings -D clippy::pedantic -D clippy::dbg-macro -D clippy::indexing-slicing -A clippy::missing-panics-doc

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,6 @@ name = "fuzz"
 version = "0.1.0"
 edition = "2021"
 
-
 [dependencies]
 honggfuzz = "0.5.55"
 ur = { path = ".." }


### PR DESCRIPTION
cargo-sort-ck has been renamed to cargo-sort [1].

[1] https://github.com/dspicher/ur-rs/actions/runs/3562195993/jobs/5983717315