### PR TITLE
Optimize some allocations.

### DIFF
--- a/src/bytewords.rs
+++ b/src/bytewords.rs
@@ -114,20 +114,20 @@ fn decode_from_index(
     indexes: &phf::Map<&'static str, u8>,
 ) -> Result<Vec<u8>, Error> {
     strip_checksum(
-        &keys
-            .map(|k| indexes.get(k).copied())
+        keys.map(|k| indexes.get(k).copied())
             .collect::<Option<Vec<_>>>()
             .ok_or(Error::InvalidWord)?,
     )
 }
 
-fn strip_checksum(data: &[u8]) -> Result<Vec<u8>, Error> {
+fn strip_checksum(mut data: Vec<u8>) -> Result<Vec<u8>, Error> {
     if data.len() < 4 {
         return Err(Error::InvalidChecksum);
     }
     let (payload, checksum) = data.split_at(data.len() - 4);
     if crate::crc32().checksum(payload).to_be_bytes() == checksum {
-        Ok(payload.to_vec())
+        data.truncate(data.len() - 4);
+        Ok(data)
     } else {
         Err(Error::InvalidChecksum)
     }

--- a/src/fountain.rs
+++ b/src/fountain.rs
@@ -599,13 +599,26 @@ impl Part {
     }
 }
 
+/// Calculates the quotient of `a` and `b`, rounding the results towards
+/// positive infinity.
+///
+/// Note: there's an implementation on the `usize` type of this function,
+/// but it's not stable yet.
 #[must_use]
-#[allow(clippy::cast_possible_truncation)]
-#[allow(clippy::cast_precision_loss)]
-#[allow(clippy::cast_sign_loss)]
+fn div_ceil(a: usize, b: usize) -> usize {
+    let d = a / b;
+    let r = a % b;
+    if r > 0 {
+        d + 1
+    } else {
+        d
+    }
+}
+
+#[must_use]
 pub(crate) fn fragment_length(data_length: usize, max_fragment_length: usize) -> usize {
-    let fragment_count = data_length / max_fragment_length + 1;
-    (data_length as f64 / fragment_count as f64).ceil() as usize
+    let fragment_count = div_ceil(data_length, max_fragment_length);
+    div_ceil(data_length, fragment_count)
 }
 
 #[must_use]

--- a/src/fountain.rs
+++ b/src/fountain.rs
@@ -620,9 +620,14 @@ fn choose_fragments(sequence: usize, fragment_count: usize, checksum: u32) -> Ve
     if sequence <= fragment_count {
         return vec![sequence - 1];
     }
+
     #[allow(clippy::cast_possible_truncation)]
-    let mut seed: Vec<u8> = (sequence as u32).to_be_bytes().to_vec();
-    seed.extend((checksum as u32).to_be_bytes().to_vec());
+    let sequence = sequence as u32;
+
+    let mut seed = [0u8; 8];
+    seed[0..4].copy_from_slice(&sequence.to_be_bytes());
+    seed[4..8].copy_from_slice(&checksum.to_be_bytes());
+
     let mut xoshiro = crate::xoshiro::Xoshiro256::from(seed.as_slice());
     let degree = xoshiro.choose_degree(fragment_count);
     let indexes = (0..fragment_count).collect();


### PR DESCRIPTION
Just optimized some allocations and made math more simple in the `fragment_length` calculation to use ceiling divisions (dividing and rounding the result up).