### PR TITLE
ur: add initial no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,12 @@ authors = ["Dominik Spicher <dominikspicher@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/dspicher/ur-rs/"
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
-bitcoin_hashes = "0.11.0"
+bitcoin_hashes = { version = "0.11.0", default-features = false }
 crc = "3.0.0"
 minicbor = { version = "0.18.0", features = ["alloc"] }
 phf = { version = "0.11.1", features = ["macros"], default-features = false }

--- a/src/bytewords.rs
+++ b/src/bytewords.rs
@@ -36,6 +36,13 @@
 //! assert_eq!(data, decode(&encoded, Style::Minimal).unwrap());
 //! ```
 
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(feature = "std")]
+use std::fmt;
+
 /// The three different `bytewords` encoding styles. See the [`encode`] documentation for examples.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Style {
@@ -56,8 +63,8 @@ pub enum Error {
     InvalidChecksum,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::InvalidWord => write!(f, "invalid word"),
             Error::InvalidChecksum => write!(f, "invalid checksum"),
@@ -65,6 +72,7 @@ impl std::fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// Decodes a `bytewords`-encoded String back into a byte payload. The encoding

--- a/src/fountain.rs
+++ b/src/fountain.rs
@@ -82,7 +82,20 @@
 //! );
 //! ```
 
-use std::convert::Infallible;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    string::String,
+    vec::Vec,
+};
+#[cfg(not(feature = "std"))]
+use core::{convert::Infallible, fmt};
+#[cfg(feature = "std")]
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    convert::Infallible,
+    fmt,
+};
 
 /// Errors that can happen during fountain encoding and decoding.
 #[derive(Debug)]
@@ -105,8 +118,8 @@ pub enum Error {
     InvalidPadding,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CborDecode(e) => write!(f, "{e}"),
             Self::CborEncode(e) => write!(f, "{e}"),
@@ -273,10 +286,10 @@ impl Encoder {
 /// See the [`crate::fountain`] module documentation for an example.
 #[derive(Default)]
 pub struct Decoder {
-    decoded: std::collections::HashMap<usize, Part>,
-    received: std::collections::HashSet<Vec<usize>>,
-    buffer: std::collections::HashMap<Vec<usize>, Part>,
-    queue: std::collections::VecDeque<(usize, Part)>,
+    decoded: BTreeMap<usize, Part>,
+    received: BTreeSet<Vec<usize>>,
+    buffer: BTreeMap<Vec<usize>, Part>,
+    queue: VecDeque<(usize, Part)>,
     sequence_count: usize,
     message_length: usize,
     checksum: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,11 @@
 //!    and emits an unbounded stream of parts which can be recombined at the receiving
 //!    decoder side.
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), macro_use)]
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 pub mod bytewords;
 pub(crate) mod constants;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 #[derive(Debug)]
 pub(crate) struct Weighted {
     aliases: Vec<u32>,

--- a/src/ur.rs
+++ b/src/ur.rs
@@ -26,6 +26,13 @@
 //! assert_eq!(decoder.message().unwrap().as_deref(), Some(data.as_bytes()));
 //! ```
 
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(feature = "std")]
+use std::fmt;
+
 /// Errors that can happen during encoding and decoding of URs.
 #[derive(Debug)]
 pub enum Error {
@@ -43,8 +50,8 @@ pub enum Error {
     NotMultiPart,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Bytewords(e) => write!(f, "{e}"),
             Error::Fountain(e) => write!(f, "{e}"),
@@ -294,7 +301,11 @@ impl Decoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "std"))]
+    use core::convert::Infallible;
     use minicbor::{bytes::ByteVec, data::Tag};
+    #[cfg(feature = "std")]
+    use std::convert::Infallible;
 
     fn make_message_ur(length: usize, seed: &str) -> Vec<u8> {
         let message = crate::xoshiro::test_utils::make_message(seed, length);
@@ -348,7 +359,7 @@ mod tests {
     fn test_ur_encoder_decoder_bc_crypto_request() {
         // https://github.com/BlockchainCommons/crypto-commons/blob/67ea252f4a7f295bb347cb046796d5b445b3ad3c/Docs/ur-99-request-response.md#the-seed-request
 
-        fn crypto_seed() -> Result<Vec<u8>, minicbor::encode::Error<std::convert::Infallible>> {
+        fn crypto_seed() -> Result<Vec<u8>, minicbor::encode::Error<Infallible>> {
             let mut e = minicbor::Encoder::new(Vec::new());
 
             let uuid = hex::decode("020C223A86F7464693FC650EF3CAC047").unwrap();

--- a/src/xoshiro.rs
+++ b/src/xoshiro.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use bitcoin_hashes::Hash;
 use rand_xoshiro::rand_core::RngCore;
 use rand_xoshiro::rand_core::SeedableRng;


### PR DESCRIPTION
Basic `no_std` support using the `alloc` crate for heap structures.

Shouldn't be merged yet as I included a conflicting change in #162. I'll rebase if that one gets merged.