### PR TITLE
ur: use index based slicing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Check
       run: cargo check --locked
     - name: Clippy
-      run: cargo clippy --all --all-targets --all-features -- -Dwarnings -D clippy::pedantic -D clippy::dbg-macro -D clippy::indexing-slicing -A clippy::missing-panics-doc
+      run: cargo clippy --all --all-targets --all-features -- -Dwarnings -D clippy::pedantic -D clippy::dbg-macro -A clippy::missing-panics-doc
     - name: Build
       run: cargo build
     - name: Run tests
@@ -42,4 +42,4 @@ jobs:
         cargo fmt -- --check
         cargo sort --check
         cargo check
-        cargo clippy --all --all-targets --all-features -- -Dwarnings -D clippy::pedantic -D clippy::dbg-macro -D clippy::indexing-slicing -A clippy::missing-panics-doc
+        cargo clippy --all --all-targets --all-features -- -Dwarnings -D clippy::pedantic -D clippy::dbg-macro -A clippy::missing-panics-doc

--- a/src/fountain.rs
+++ b/src/fountain.rs
@@ -213,9 +213,9 @@ impl Encoder {
         self.current_sequence += 1;
         let indexes = choose_fragments(self.current_sequence, self.parts.len(), self.checksum);
 
-        let mut mixed = vec![0; self.parts.get(0).unwrap().len()];
+        let mut mixed = vec![0; self.parts[0].len()];
         for item in indexes {
-            xor(&mut mixed, self.parts.get(item).unwrap());
+            xor(&mut mixed, &self.parts[item]);
         }
 
         Part {
@@ -708,11 +708,8 @@ mod tests {
             "170010067e2e75ebe2d2904aeb1f89d5dc98cd4a6f2faaa8be6d03354c990fd895a97feb54668473e9d942bb99e196d897e8f1b01625cf48a7b78d249bb4985c065aa8cd1402ed2ba1b6f908f63dcd84b66425df00000000000000000000"
         ];
         assert_eq!(fragments.len(), expected_fragments.len());
-        for i in 0..fragments.len() {
-            assert_eq!(
-                hex::encode(fragments.get(i).unwrap()),
-                *expected_fragments.get(i).unwrap()
-            );
+        for (fragment, expected_fragment) in fragments.iter().zip(expected_fragments) {
+            assert_eq!(hex::encode(fragment), expected_fragment);
         }
         let rejoined = join(fragments, message.len());
         assert_eq!(rejoined, message);
@@ -759,10 +756,7 @@ mod tests {
         for seq_num in 1..=30 {
             let mut indexes = crate::fountain::choose_fragments(seq_num, fragments.len(), checksum);
             indexes.sort_unstable();
-            assert_eq!(
-                indexes,
-                *expected_fragment_indexes.get(seq_num - 1).unwrap()
-            );
+            assert_eq!(indexes, expected_fragment_indexes[seq_num - 1]);
         }
     }
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -20,7 +20,7 @@ impl Weighted {
         }
         let (mut s, mut l): (Vec<usize>, Vec<usize>) = (1..=count)
             .map(|j| count - j)
-            .partition(|&j| *weights.get(j).unwrap() < 1.0);
+            .partition(|&j| weights[j] < 1.0);
 
         let mut probs: Vec<f64> = vec![0.0; count];
         let mut aliases: Vec<u32> = vec![0; count];
@@ -28,10 +28,10 @@ impl Weighted {
         while !s.is_empty() && !l.is_empty() {
             let a = s.remove(s.len() - 1);
             let g = l.remove(l.len() - 1);
-            *probs.get_mut(a).unwrap() = *weights.get(a).unwrap();
-            *aliases.get_mut(a).unwrap() = g as u32;
-            *weights.get_mut(g).unwrap() += *weights.get(a).unwrap() - 1.0;
-            if *weights.get(g).unwrap() < 1.0 {
+            probs[a] = weights[a];
+            aliases[a] = g as u32;
+            weights[g] += weights[a] - 1.0;
+            if weights[g] < 1.0 {
                 s.push(g);
             } else {
                 l.push(g);
@@ -40,12 +40,12 @@ impl Weighted {
 
         while !l.is_empty() {
             let g = l.remove(l.len() - 1);
-            *probs.get_mut(g).unwrap() = 1.0;
+            probs[g] = 1.0;
         }
 
         while !s.is_empty() {
             let a = s.remove(s.len() - 1);
-            *probs.get_mut(a).unwrap() = 1.0;
+            probs[a] = 1.0;
         }
 
         Self { aliases, probs }
@@ -57,10 +57,10 @@ impl Weighted {
         let r2 = xoshiro.next_double();
         let n = self.probs.len();
         let i = (n as f64 * r1) as usize;
-        if r2 < *self.probs.get(i).unwrap() {
+        if r2 < self.probs[i] {
             i as u32
         } else {
-            *self.aliases.get(i).unwrap()
+            self.aliases[i]
         }
     }
 }
@@ -119,7 +119,7 @@ mod tests {
             let mut xoshiro = crate::xoshiro::Xoshiro256::from(format!("Wolf-{nonce}").as_str());
             assert_eq!(
                 xoshiro.choose_degree(fragments.len()),
-                *expected_degrees.get(nonce - 1).unwrap()
+                expected_degrees[nonce - 1]
             );
         }
     }

--- a/src/xoshiro.rs
+++ b/src/xoshiro.rs
@@ -69,11 +69,11 @@ impl From<[u8; 32]> for Xoshiro256 {
             let mut v: u64 = 0;
             for n in 0..8 {
                 v <<= 8;
-                v |= u64::from(*value.get(8 * i + n).unwrap());
+                v |= u64::from(value[8 * i + n]);
             }
             let bytes = v.to_le_bytes();
             for n in 0..8 {
-                *s.get_mut(8 * i + n).unwrap() = *bytes.get(n).unwrap();
+                s[8 * i + n] = bytes[n];
             }
         }
         Xoshiro256StarStar::from_seed(s).into()


### PR DESCRIPTION
This removes the `clippy::indexing-slicing` from the CI as we use the `.get` method on `Vec` and slices as we are using `unwrap` on it anyway.

Using index-based slicing lets the user of the crate remove the bounds check (once the code is proven to work correctly) and is a bit more readable, for code that we should handle the error where the index is off we should use `get` instead.