### PR TITLE
ur: introduce type-safe handling of ur type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
  - Added support for `no-std` environments. https://github.com/dspicher/ur-rs/pull/183
+ - Introduced a type-safe `ur::Type` enum and a `ur::Encoder::bytes` shorthand constructor. https://github.com/dspicher/ur-rs/pull/186
 
 ## [0.3.0] - 2023-01-07
  - Added `ur::ur::decode` to the public API to decode a single `ur` URI. https://github.com/dspicher/ur-rs/pull/112

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ subsets of which can be recombined at the receiving side into the payload:
 ```rust
 let data = String::from("Ten chars!").repeat(10);
 let max_length = 5;
-let scheme = "bytes";
-let mut encoder = ur::Encoder::new(data.as_bytes(), max_length, scheme).unwrap();
+let mut encoder = ur::Encoder::bytes(data.as_bytes(), max_length).unwrap();
 let part = encoder.next_part().unwrap();
 assert_eq!(
     part,

--- a/examples/qr.rs
+++ b/examples/qr.rs
@@ -3,8 +3,7 @@ use qrcode::QrCode;
 use std::io::Write;
 
 fn main() {
-    let mut encoder =
-        ur::Encoder::new(std::env::args().last().unwrap().as_bytes(), 5, "bytes").unwrap();
+    let mut encoder = ur::Encoder::bytes(std::env::args().last().unwrap().as_bytes(), 5).unwrap();
     let mut stdout = std::io::stdout();
     loop {
         let ur = encoder.next_part().unwrap();

--- a/fuzz/fuzz_targets/ur_encode.rs
+++ b/fuzz/fuzz_targets/ur_encode.rs
@@ -4,7 +4,7 @@ fn main() {
     loop {
         fuzz!(|data: &[u8]| {
             let max_length = 1 + *data.first().unwrap() as usize;
-            let mut encoder = ur::Encoder::new(data, max_length, "bytes").unwrap();
+            let mut encoder = ur::Encoder::bytes(data, max_length).unwrap();
             let mut decoder = ur::Decoder::default();
             for _ in 0..encoder.fragment_count() {
                 let part = encoder.next_part().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,7 @@
 //! ```
 //! let data = String::from("Ten chars!").repeat(10);
 //! let max_length = 5;
-//! let scheme = "bytes";
-//! let mut encoder = ur::Encoder::new(data.as_bytes(), max_length, scheme).unwrap();
+//! let mut encoder = ur::Encoder::bytes(data.as_bytes(), max_length).unwrap();
 //! let part = encoder.next_part().unwrap();
 //! assert_eq!(
 //!     part,
@@ -52,6 +51,7 @@ pub use self::ur::decode;
 pub use self::ur::encode;
 pub use self::ur::Decoder;
 pub use self::ur::Encoder;
+pub use self::ur::Type;
 
 #[must_use]
 pub(crate) const fn crc32() -> crc::Crc<u32> {


### PR DESCRIPTION
Avoid forcing the user to supply a raw string
argument for the usual "bytes" case.