### PR TITLE
ci/clippy: lint exported api

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false


### PR DESCRIPTION
We can make this more stable again
when the library has reached a more
mature stage.