### PR TITLE
ci: use cargo-quickinstall to install crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install crates
-      run: cargo install --debug cargo-sort cargo-rdme cargo-audit cargo-udeps
+      run: |
+        cargo install --debug cargo-quickinstall
+        cargo quickinstall cargo-sort cargo-rdme cargo-audit cargo-udeps
     - name: Lint
       run: |
         cargo fmt -- --check --config format_code_in_doc_comments=true


### PR DESCRIPTION
This cuts down roughly 5m30s from our 8m main CI
stage.