### PR TITLE
ci/coverage: add token env var

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,3 +28,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Tokenless uploads have been discontinued [1].

[1] https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release